### PR TITLE
docs: update README with setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Key variables:
   - `JWT_SECRET`: Secret used to sign renewal JWTs **(required)**
   - `RENEWAL_DURATION_DAYS`: Days added on renew (defaults to 90)
 - `frontend/.env`
-  - `NEXT_PUBLIC_API_BASE_URL`: URL pointing to the backend (defaults to `http://localhost:4100`)
+  - `NEXT_PUBLIC_API_BASE_URL`: URL pointing to the backend (defaults to `http://localhost:4000`)
 
 ### 4. Run the development servers
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,26 @@ cd ../backend
 npm install
 ```
 
-### 3. Run the development servers
+### 3. Configure environment variables
+
+Create `.env` files from the provided examples and fill in secure values:
+
+```bash
+cp backend/.env.example backend/.env
+cp frontend/.env.example frontend/.env
+```
+
+Key variables:
+
+- `backend/.env`
+  - `PORT`: Express server port (defaults to 4000)
+  - `SERVER_URL`: Public URL for Swagger docs (defaults to `http://localhost:PORT`)
+  - `JWT_SECRET`: Secret used to sign renewal JWTs **(required)**
+  - `RENEWAL_DURATION_DAYS`: Days added on renew (defaults to 90)
+- `frontend/.env`
+  - `NEXT_PUBLIC_API_BASE_URL`: URL pointing to the backend (defaults to `http://localhost:4100`)
+
+### 4. Run the development servers
 
 In one terminal tab, start the backend (defaults to port `4000`):
 
@@ -43,7 +62,7 @@ cd backend
 npm run dev
 ```
 
-In another tab, start the frontend (defaults to port `3000`):
+In another tab, start the frontend (defaults to port `3000`, fallback to `3001` if occupied):
 
 ```bash
 cd frontend
@@ -57,7 +76,10 @@ cd backend
 node -e "const jwt=require('jsonwebtoken');console.log(jwt.sign({ tokenId: 'token-1' }, process.env.JWT_SECRET || 'replace-with-secure-secret', { expiresIn: '90d' }));"
 ```
 
-Paste the resulting token into the frontend renew modal; the UI will handle the `Bearer` prefix.
+Paste the resulting token into the frontend renew modal (Authorization field). The UI automatically prefixes it with `Bearer` and shows the newly issued JWT after a successful renew.
+
+Swagger docs are available at `http://localhost:<PORT>/docs` once the backend is running.
+The OpenAPI specification lives at `backend/openapi.yaml` and powers both the Swagger UI and importable client references.
 
 ## Available Scripts
 
@@ -73,11 +95,6 @@ Paste the resulting token into the frontend renew modal; the UI will handle the 
 - `npm run dev` – start Express server with live reload (`nodemon`)
 - `npm run build` – compile TypeScript to `dist/`
 - `npm run start` – run compiled server
-
-## Next Steps
-
-- Implement `/api/tokens` on the backend to return mock token data
-- Build the Access Manager UI in the frontend (table, filters, renew button)
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- document environment variable setup for backend/frontend
- clarify dev server behavior and JWT generation for renewals
- mention Swagger docs and OpenAPI spec location